### PR TITLE
Feat SocialLogin & Profile Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ local_settings.py
 media
 migrations
 .env
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 local_settings.py
 media
 migrations
+.env

--- a/backend/accounts/authentication.py
+++ b/backend/accounts/authentication.py
@@ -8,9 +8,9 @@ from backend import settings
 
 
 class CustomJWTAuthentication(BaseAuthentication):
-    '''
-        custom authentication class for DRF and JWT
-    '''
+    """
+    custom authentication class for DRF and JWT
+    """
 
     def authenticate(self, request):
 

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -134,6 +134,10 @@ class User(AbstractBaseUser, CustomPermissionsMixin):
         verbose_name=_('Is active'),
         default=True
     )
+    is_social = models.BooleanField(
+        verbose_name=_('Is social account'),
+        default=False
+    )
     date_joined = models.DateTimeField(
         verbose_name=_('Date joined'),
         default=timezone.now

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -188,8 +188,8 @@ class User(AbstractBaseUser, CustomPermissionsMixin):
 
 
 class Follow(models.Model):
-    from_user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name='following')
-    to_user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name='followers')
+    from_user = models.ForeignKey(User, on_delete=models.CASCADE, null=True, related_name='following')
+    to_user = models.ForeignKey(User, on_delete=models.CASCADE, null=True, related_name='followers')
 
     class Meta:
         db_table = 'follow'

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -3,6 +3,8 @@ from django.contrib.auth.models import (
     _user_has_module_perms
 )
 from django.db import models
+from django.contrib.postgres.fields import ArrayField
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
@@ -136,22 +138,10 @@ class User(AbstractBaseUser, CustomPermissionsMixin):
         verbose_name=_('Date joined'),
         default=timezone.now
     )
-    followers = models.ManyToManyField(
-        "self",
-        blank=True,
-        symmetrical=False,
-        related_name="recordmusic_followers"
+    profile_image = ArrayField(
+        models.ImageField(), null=True, blank=True
     )
-
-    following = models.ManyToManyField(
-        "self",
-        blank=True,
-        symmetrical=False,
-        related_name="recordmusic_following"
-    )
-    profile_image = models.ImageField(
-        null=True
-    )
+    follows = models.ManyToManyField("self", through="Follow", symmetrical=False)
 
     objects = UserManager()
 
@@ -177,7 +167,7 @@ class User(AbstractBaseUser, CustomPermissionsMixin):
         return self.email
 
     def get_absolute_url(self):
-        return reversed('users:detail', kwargs={'user_id': self.user_id})
+        return reverse('users:detail', kwargs={'user_id': self.user_id})
 
     @property
     def is_staff(self):
@@ -191,3 +181,11 @@ class User(AbstractBaseUser, CustomPermissionsMixin):
     @property
     def following_count(self):
         return self.following.all().count()
+
+
+class Follow(models.Model):
+    from_user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name='following')
+    to_user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name='followers')
+
+    class Meta:
+        db_table = 'follow'

--- a/backend/accounts/socialloginview.py
+++ b/backend/accounts/socialloginview.py
@@ -3,6 +3,7 @@ import json
 import requests
 
 from django.shortcuts import redirect
+from django.urls import reverse
 from rest_framework import status, permissions
 from rest_framework.decorators import api_view, renderer_classes, permission_classes
 from rest_framework.renderers import JSONRenderer
@@ -14,6 +15,8 @@ from accounts.serializers import UserSerializerWithToken
 from backend import settings
 
 
+# ----- FACEBOOK ----- #
+
 @api_view(('GET',))
 @permission_classes((permissions.AllowAny,))
 def fblogin(request):
@@ -21,10 +24,11 @@ def fblogin(request):
     Redirect to Facebook account linking
     """
     app_id = settings.FACEBOOK_APP_ID
+    redirect_uri = reverse('accounts:facebook_login_redirect')
 
     url = f'https://www.facebook.com/v7.0/dialog/oauth?' \
           f'client_id={app_id}' \
-          f'&redirect_uri=http://localhost:9080/accounts/sociallogin/facebook/redirect/' \
+          f'&redirect_uri=http://localhost:9080{redirect_uri}' \
           f'&scope=email,public_profile'
     return redirect(url)
 
@@ -35,13 +39,14 @@ def fblogin(request):
 def fblogin_redirect(request):
     app_id = settings.FACEBOOK_APP_ID
     app_secret = settings.FACEBOOK_APP_SECRET
+    redirect_uri = reverse('accounts:facebook_login_redirect')
 
     # get access token from redirected url.
     code = request.GET['code']
     url = 'https://graph.facebook.com/v4.0/oauth/access_token'
     params = {
         'client_id': settings.FACEBOOK_APP_ID,
-        'redirect_uri': 'http://localhost:9080/accounts/sociallogin/facebook/redirect/',
+        'redirect_uri': f'http://localhost:9080{redirect_uri}',
         'client_secret': settings.FACEBOOK_APP_SECRET,
         'code': code,
     }
@@ -78,8 +83,29 @@ def fblogin_redirect(request):
     user_info = requests.get(url_user_info, params=params_user_info)
     user_info = user_info.json()
 
+    """
+    Possible output of user_info:
+    
+    ('id', 'test_id')
+    ('first_name', 'Jun Hyeok')
+    ('last_name', 'Lee')
+    ('picture', {
+        'data': {
+            'height': 50, 
+            'is_silhouette': False, 
+            'url': 'https://scontent.xx.fbcdn.net/v/t1.0-1/...', 
+            'width': 50
+            }
+        }
+    )
+    ('email', 'bnbong@naver.com')
+    
+    etc..
+    """
+
     try:
         # login with social account if social account is in User
+
         email = json.dumps(user_info['email'])
         email = email.replace('"', '')
         user = User.objects.get(email=email)
@@ -102,9 +128,149 @@ def fblogin_redirect(request):
 
     except User.DoesNotExist:
         # make new account with social account
+
         email = user_info['email']
         user_id = email.split('@')[0]
         username = user_info['last_name'] + user_info['first_name']
+
+        # for security, make account based with social account that user provides us
+        # with random password and hashes it so outsider cannot open corresponding account's info.
+        password = User.objects.make_random_password()
+
+        user = User(
+            email=email,
+            user_id=user_id,
+            username=username,
+            is_social=True,
+        )
+        user.set_password(password)
+        user.save()
+
+        serializer = UserSerializerWithToken(user)
+
+        user_token = serializer.data.get('token')
+        data = {'token': user_token,
+                'user': {
+                    "profile_image": serializer.data.get('profile_image'),
+                    "user_id": serializer.data.get('user_id'),
+                    "email": serializer.data.get('email')
+                    }
+                }
+
+        return Response(data=data, status=status.HTTP_201_CREATED)
+
+
+# ----- GOOGLE ----- #
+
+@api_view(('GET',))
+@permission_classes((permissions.AllowAny,))
+def gglogin(request):
+    """
+    Redirect to Facebook account linking
+    """
+    app_id = settings.GOOGLE_APP_ID
+    redirect_uri = reverse('accounts:google_login_redirect')
+
+    url = f'https://accounts.google.com/o/oauth2/auth/oauthchooseaccount?' \
+          f'client_id={app_id}' \
+          f'&redirect_uri=http://localhost:9080{redirect_uri}' \
+          f'&scope=https://www.googleapis.com/auth/userinfo.email' \
+          f' https://www.googleapis.com/auth/userinfo.profile' \
+          f' openid' \
+          f'&response_type=code'
+    return redirect(url)
+
+
+@api_view(('GET',))
+@permission_classes((permissions.AllowAny,))
+@renderer_classes((JSONRenderer,))
+def gglogin_redirect(request):
+    app_id = settings.GOOGLE_APP_ID
+    app_secret = settings.GOOGLE_APP_SECRET
+    redirect_uri = reverse('accounts:google_login_redirect')
+
+    # get access token from redirected url.
+    code = request.GET['code']
+    verify_oauth2_token_url = f'https://accounts.google.com/o/oauth2/token?code={code}' \
+                              f'&redirect_uri=http://localhost:9080{redirect_uri}' \
+                              f'&client_id={app_id}' \
+                              f'&client_secret={app_secret}' \
+                              f'&grant_type=authorization_code'
+    token_response = requests.post(verify_oauth2_token_url)
+
+    id_token = token_response.json()['id_token']
+    user_info_url = f'https://oauth2.googleapis.com/tokeninfo?id_token={id_token}'
+    user_info = requests.get(user_info_url)
+    user_info = user_info.json()
+
+    """
+    Possible output of user_info:
+    
+    {
+    // These six fields are included in all Google ID Tokens.
+    "iss": "https://accounts.google.com",
+    "sub": "110169484474386276334",
+    "azp": "1008719970978-hb24n2dstb40o45d4feuo2ukqmcc6381.apps.googleusercontent.com",
+    "aud": "1008719970978-hb24n2dstb40o45d4feuo2ukqmcc6381.apps.googleusercontent.com",
+    "iat": "1433978353",
+    "exp": "1433981953",
+
+    // These seven fields are only included when the user has granted the "profile" and
+    // "email" OAuth scopes to the application.
+    "email": "testuser@gmail.com",
+    "email_verified": "true",
+    "name" : "Test User",
+    "picture": "https://lh4.googleusercontent.com/-kYgzyAWpZzJ/ABCDEFGHI/AAAJKLMNOP/tIXL9Ir44LE/s99-c/photo.jpg",
+    "given_name": "Test",
+    "family_name": "User",
+    "locale": "en"
+    
+    etc..
+    }
+    """
+
+    try:
+        # login with social account if social account is in User
+
+        email = json.dumps(user_info['email'])
+        email = email.replace('"', '')
+        user = User.objects.get(email=email)
+        if user.is_social is False:
+            return Response(data={"detail": _("User already exists and not registered with social account.")},
+                            status=status.HTTP_403_FORBIDDEN)
+
+        serializer = UserSerializerWithToken(user)
+
+        user_token = serializer.data.get('token')
+        data = {'token': user_token,
+                'user': {
+                    "profile_image": serializer.data.get('profile_image'),
+                    "user_id": serializer.data.get('user_id'),
+                    "email": serializer.data.get('email')
+                    }
+                }
+
+        return Response(data=data, status=status.HTTP_200_OK)
+
+    except User.DoesNotExist:
+        # make new account with social account
+        try:
+            email = user_info['email']
+        except KeyError:
+            return Response(data={"detail": _("The email for that social account could not be found. "
+                                              "Please make your email public so that we can check your email.")},
+                            status=status.HTTP_403_FORBIDDEN)
+
+        user_id = email.split('@')[0]
+        # if user have not granted "profile" and cannot see user's name
+        try:
+            username = user_info['name']
+
+        except KeyError:
+            username = ''
+
+        # for security, make account based with social account that user provides us
+        # with random password and hashes it so outsider cannot open corresponding account's info.
         password = User.objects.make_random_password()
 
         user = User(

--- a/backend/accounts/socialloginview.py
+++ b/backend/accounts/socialloginview.py
@@ -1,0 +1,130 @@
+import json
+
+import requests
+
+from django.shortcuts import redirect
+from rest_framework import status, permissions
+from rest_framework.decorators import api_view, renderer_classes, permission_classes
+from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
+from django.utils.translation import ugettext_lazy as _
+
+from accounts.models import User
+from accounts.serializers import UserSerializerWithToken
+from backend import settings
+
+
+@api_view(('GET',))
+@permission_classes((permissions.AllowAny,))
+def fblogin(request):
+    """
+    Redirect to Facebook account linking
+    """
+    app_id = settings.FACEBOOK_APP_ID
+
+    url = f'https://www.facebook.com/v7.0/dialog/oauth?' \
+          f'client_id={app_id}' \
+          f'&redirect_uri=http://localhost:9080/accounts/sociallogin/facebook/redirect/' \
+          f'&scope=email,public_profile'
+    return redirect(url)
+
+
+@api_view(('GET',))
+@permission_classes((permissions.AllowAny,))
+@renderer_classes((JSONRenderer,))
+def fblogin_redirect(request):
+    app_id = settings.FACEBOOK_APP_ID
+    app_secret = settings.FACEBOOK_APP_SECRET
+
+    # get access token from redirected url.
+    code = request.GET['code']
+    url = 'https://graph.facebook.com/v4.0/oauth/access_token'
+    params = {
+        'client_id': settings.FACEBOOK_APP_ID,
+        'redirect_uri': 'http://localhost:9080/accounts/sociallogin/facebook/redirect/',
+        'client_secret': settings.FACEBOOK_APP_SECRET,
+        'code': code,
+    }
+
+    # debug access token is valid form.
+    response = requests.get(url, params)
+    url_debug_token = 'https://graph.facebook.com/debug_token'
+
+    access_token = response.json()['access_token']
+
+    params_debug_token = {
+        "input_token": access_token,
+        "access_token": f'{app_id}|{app_secret}'
+    }
+
+    debug_info = requests.get(url_debug_token, params=params_debug_token)
+
+    if not debug_info.json()['data']:
+        return Response(data={"detail": _("Invalid social account.")}, status=status.HTTP_403_FORBIDDEN)
+
+    url_user_info = 'https://graph.facebook.com/me'
+    user_info_fields = [
+        'id',
+        'first_name',
+        'last_name',
+        'picture',
+        'email',
+    ]
+    params_user_info = {
+        "fields": ','.join(user_info_fields),
+        "access_token": access_token
+    }
+
+    user_info = requests.get(url_user_info, params=params_user_info)
+    user_info = user_info.json()
+
+    try:
+        # login with social account if social account is in User
+        email = json.dumps(user_info['email'])
+        email = email.replace('"', '')
+        user = User.objects.get(email=email)
+        if user.is_social is False:
+            return Response(data={"detail": _("User already exists and not registered with social account.")},
+                            status=status.HTTP_403_FORBIDDEN)
+
+        serializer = UserSerializerWithToken(user)
+
+        user_token = serializer.data.get('token')
+        data = {'token': user_token,
+                'user': {
+                    "profile_image": serializer.data.get('profile_image'),
+                    "user_id": serializer.data.get('user_id'),
+                    "email": serializer.data.get('email')
+                    }
+                }
+
+        return Response(data=data, status=status.HTTP_200_OK)
+
+    except User.DoesNotExist:
+        # make new account with social account
+        email = user_info['email']
+        user_id = email.split('@')[0]
+        username = user_info['last_name'] + user_info['first_name']
+        password = User.objects.make_random_password()
+
+        user = User(
+            email=email,
+            user_id=user_id,
+            username=username,
+            is_social=True,
+        )
+        user.set_password(password)
+        user.save()
+
+        serializer = UserSerializerWithToken(user)
+
+        user_token = serializer.data.get('token')
+        data = {'token': user_token,
+                'user': {
+                    "profile_image": serializer.data.get('profile_image'),
+                    "user_id": serializer.data.get('user_id'),
+                    "email": serializer.data.get('email')
+                    }
+                }
+
+        return Response(data=data, status=status.HTTP_201_CREATED)

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.utils.http import base36_to_int
 from rest_framework.test import APITestCase, APIClient
 from .authentication import *
-from accounts.models import Follow
+from accounts.models import *
 from backend import settings
 from .serializers import jwt_encode_handler
 from .views import *
@@ -26,8 +26,8 @@ class ModelTest(TestCase):
             'email': 'test@testmail.com',
             'password': 'junhyeok'
         }
-        User.objects.create_user(user_id=cls.userdata.get('user_id'), username=cls.userdata.get('username'),
-                                 email=cls.userdata.get('email'), password=cls.userdata.get('password'))
+        User.objects.create(user_id=cls.userdata.get('user_id'), username=cls.userdata.get('username'),
+                                 email=cls.userdata.get('email'), password=cls.userdata.get('password')).save()
 
         cls.userdata2 = {
             'user_id': 'test2',
@@ -35,8 +35,8 @@ class ModelTest(TestCase):
             'email': 'test2@testmail.com',
             'password': 'junhyeok'
         }
-        User.objects.create_user(user_id=cls.userdata2.get('user_id'), username=cls.userdata2.get('username'),
-                                 email=cls.userdata2.get('email'), password=cls.userdata2.get('password'))
+        User.objects.create(user_id=cls.userdata2.get('user_id'), username=cls.userdata2.get('username'),
+                                 email=cls.userdata2.get('email'), password=cls.userdata2.get('password')).save()
 
     def test_should_make_user_models(self):
 
@@ -71,10 +71,14 @@ class ModelTest(TestCase):
         user2 = User.objects.get(user_id='test2')
         user3 = User.objects.get(user_id='test3')
 
-        Follow.objects.get_or_create(from_user=user1, to_user=user2)
-        Follow.objects.get_or_create(from_user=user1, to_user=user3)
-        Follow.objects.get_or_create(from_user=user3, to_user=user1)
+        user1.follows.add(user2)
+        user1.follows.add(user3)
+        user3.follows.add(user1)
 
+        expect_response = User.objects.get(user_id='test2'), User.objects.get(user_id='test3')
+        expect_response = list(expect_response)
+
+        self.assertEqual(list(user1.follows.all()), expect_response)
         self.assertEqual(1, user1.following.values()[0].get('from_user_id'))
 
         followers = []

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -5,10 +5,9 @@ from django.utils.http import base36_to_int
 from rest_framework.test import APITestCase, APIClient
 
 from .authentication import *
-from .serializers import jwt_encode_handler
 from .views import *
 from django.core import mail
-from django.contrib.auth.tokens import default_token_generator
+from django.contrib.auth.tokens import default_token_generator, PasswordResetTokenGenerator
 
 from .models import *
 from django.test import TestCase
@@ -20,7 +19,6 @@ class ModelTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-
         cls.userdata = {
             'user_id': 'test',
             'username': 'kimtest',
@@ -28,7 +26,7 @@ class ModelTest(TestCase):
             'password': 'junhyeok'
         }
         User.objects.create(user_id=cls.userdata.get('user_id'), username=cls.userdata.get('username'),
-                                 email=cls.userdata.get('email'), password=cls.userdata.get('password')).save()
+                            email=cls.userdata.get('email'), password=cls.userdata.get('password')).save()
 
         cls.userdata2 = {
             'user_id': 'test2',
@@ -37,10 +35,9 @@ class ModelTest(TestCase):
             'password': 'junhyeok'
         }
         User.objects.create(user_id=cls.userdata2.get('user_id'), username=cls.userdata2.get('username'),
-                                 email=cls.userdata2.get('email'), password=cls.userdata2.get('password')).save()
+                            email=cls.userdata2.get('email'), password=cls.userdata2.get('password')).save()
 
     def test_setUpData_check(self):
-
         user = User.objects.get(user_id='test')
 
         self.assertEqual('test', user.get_user_id())
@@ -99,27 +96,6 @@ class ModelTest(TestCase):
         serializer = UserProfileSerializer(followers, many=True)
 
         expect_result = OrderedDict([('profile_image', None), ('user_id', 'test'), ('username', 'kimtest'),
-                           ('email', 'test@testmail.com'), ('followers_count', 1), ('following_count', 2)])
-
-        self.assertEqual([expect_result], serializer.data)
-
-        following = user1.follows.all()
-
-        serializer = UserProfileSerializer(following, many=True)
-
-        expect_result_1, expect_result_2 = \
-            OrderedDict([('profile_image', None), ('user_id', 'test2'), ('username', 'leetest'),
-                                     ('email', 'test2@testmail.com'), ('followers_count', 1), ('following_count', 0)]),\
-            OrderedDict([('profile_image', None), ('user_id', 'test3'), ('username', 'parktest'),
-                     ('email', 'test3@testmail.com'), ('followers_count', 1), ('following_count', 1)])
-
-        self.assertEqual([expect_result_1, expect_result_2], serializer.data)
-
-        following = user3.follows.all()
-
-        serializer = UserProfileSerializer(following, many=True)
-
-        expect_result = OrderedDict([('profile_image', None), ('user_id', 'test'), ('username', 'kimtest'),
                                      ('email', 'test@testmail.com'), ('followers_count', 1), ('following_count', 2)])
 
         self.assertEqual([expect_result], serializer.data)
@@ -139,7 +115,7 @@ class ViewTest(APITestCase):
             'password': 'junhyeok'
         }
         User.objects.create_user(user_id=cls.userdata.get('user_id'), username=cls.userdata.get('username'),
-                     email=cls.userdata.get('email'), password=cls.userdata.get('password'))
+                                 email=cls.userdata.get('email'), password=cls.userdata.get('password'))
 
         cls.userdata2 = {
             'user_id': 'test2',
@@ -151,11 +127,9 @@ class ViewTest(APITestCase):
                                  email=cls.userdata2.get('email'), password=cls.userdata2.get('password'))
 
     def test_isTestUserInDB(self):
-
         self.assertEqual('test', User.objects.get(user_id='test').user_id)
 
     def test_change_isActive(self):
-
         user = User.objects.get(user_id='test')
         user.is_active = False
         self.assertEqual(False, user.is_active)
@@ -163,7 +137,6 @@ class ViewTest(APITestCase):
         self.assertEqual(True, user.is_active)
 
     def test_register_and_login(self):
-
         register_data = {
             'user_id': 'test3',
             'username': 'leetest',
@@ -250,7 +223,7 @@ class ViewTest(APITestCase):
 
         expect_result_1, expect_result_2 = \
             OrderedDict([('profile_image', None), ('user_id', 'test2'), ('username', 'leetest'),
-                         ('email', 'test2@testmail.com'), ('followers_count', 1), ('following_count', 0)]),\
+                         ('email', 'test2@testmail.com'), ('followers_count', 1), ('following_count', 0)]), \
             OrderedDict([('profile_image', None), ('user_id', 'test3'), ('username', 'ParkTest'),
                          ('email', 'test3@testmail.com'), ('followers_count', 1), ('following_count', 0)])
 
@@ -269,12 +242,11 @@ class ViewTest(APITestCase):
         self.assertEqual(1, user.following_count)
 
     def test_send_email(self):
-
         mail.send_mail('Subject here',
-                  'Here is the message.',
-                  'from@example.com',
-                  ['to@example.com'],
-                  fail_silently=False)
+                       'Here is the message.',
+                       'from@example.com',
+                       ['to@example.com'],
+                       fail_silently=False)
 
         assert len(mail.outbox) == 1, "Inbox is not empty."
         assert mail.outbox[0].subject == 'Subject here'
@@ -322,17 +294,20 @@ class ViewTest(APITestCase):
         uidb64 = urlsafe_base64_encode(force_bytes(user.user_pk))
         token = default_token_generator.make_token(user=user)  # One-time token for account authentication
 
-        def message(domain, uidb64, token):
-            return f"아래 링크를 클릭하면 회원 가입 인증이 완료됩니다.\n\n" \
-                   f"회원가입 완료 링크 : http://127.0.0.1:9080/accounts/register/activate/{uidb64}/{token}\n\n감사합니다."
-            # should change localhost domain to {domain} after register record-music domain
-            # return f"아래 링크를 클릭하면 회원 가입 인증이 완료됩니다.\n\n" \
-            #                    f"회원가입 완료 링크 : http://{domain}/accounts/register/activate/{uidb64}/{token}\n\n 감사합니다."
+        def message(domain, uidb64, token, link):
+            activation_link = f"{link}/{uidb64}/{token}"
+            return f"아래 링크를 클릭하면 회원 인증이 완료됩니다.\n\n" \
+                   f"회원 인증 완료 링크 : {activation_link}\n\n감사합니다."
 
-        self.assertEqual(f"아래 링크를 클릭하면 회원 가입 인증이 완료됩니다."
-                         f"\n\n회원가입 완료 링크 : http://127.0.0.1:9080/accounts/register/activate/{uidb64}/{token}\n\n감사합니다."
-                         , message(None, uidb64, token))
-        self.assertEqual(None, send_verification_email(request, user, user.email))
+            # should change localhost domain to {domain} after register record-music domain
+            # return f"아래 링크를 클릭하면 회원 인증이 완료됩니다.\n\n" \
+            #                    f"회원 인증 완료 링크 : http://{domain}/accounts/register/activate/{uidb64}/{token}\n\n 감사합니다."
+
+        self.assertEqual(f"아래 링크를 클릭하면 회원 인증이 완료됩니다."
+                         f"\n\n회원 인증 완료 링크 : http://127.0.0.1:9080/accounts/register/activate/{uidb64}/{token}\n\n감사합니다."
+                         , message(None, uidb64, token, 'http://127.0.0.1:9080/accounts/register/activate'))
+        self.assertEqual(None, send_verification_email(request, user, user.email,
+                                                       'http://127.0.0.1:9080/accounts/register/activate'))
 
     def test_jwt_encoding_and_authentication_check(self):
         user = User.objects.get(user_id='test')
@@ -352,21 +327,23 @@ class ViewTest(APITestCase):
         y, m, d = 2021, 1, 23
         not_over_day = date(y, m, d)
 
-        self.assertEqual(False, (default_token_generator._num_days(not_over_day) - ts) > settings.PASSWORD_RESET_TIMEOUT_DAYS)
+        self.assertEqual(False,
+                         (default_token_generator._num_days(not_over_day) - ts) > settings.PASSWORD_RESET_TIMEOUT_DAYS)
 
         y, m, d = 2021, 1, default_token_generator._today().day + 3
         over_day = date(y, m, d)
 
-        self.assertEqual(True, (default_token_generator._num_days(over_day) - ts) > settings.PASSWORD_RESET_TIMEOUT_DAYS)
+        self.assertEqual(True,
+                         (default_token_generator._num_days(over_day) - ts) > settings.PASSWORD_RESET_TIMEOUT_DAYS)
 
     def test_social_login_access_token_slice(self):
-        user_info = {"id":"my_id_here",
-                     "first_name":"\uc900\ud601",
-                     "last_name":"\uc774",
-                     "picture":{"data":{"height":50,"is_silhouette":False,
-                                        "url":"profile_url_here",
-                                        "width":50}},
-                     "email":"bnbong\u0040naver.com"}
+        user_info = {"id": "my_id_here",
+                     "first_name": "\uc900\ud601",
+                     "last_name": "\uc774",
+                     "picture": {"data": {"height": 50, "is_silhouette": False,
+                                          "url": "profile_url_here",
+                                          "width": 50}},
+                     "email": "bnbong\u0040naver.com"}
         self.assertEqual("bnbong@naver.com", user_info['email'])
         self.assertEqual("준혁", user_info['first_name'])
         self.assertEqual("이", user_info['last_name'])
@@ -376,3 +353,65 @@ class ViewTest(APITestCase):
         uri = f'http://localhost:9080{redirect_uri}'
 
         self.assertEqual('http://localhost:9080/accounts/sociallogin/google/redirect/', uri)
+
+    def test_should_update_user_profile(self):
+        client = APIClient()
+        user = User.objects.get(user_id='test')
+        client.force_authenticate(user=user)
+
+        data_email_change = {
+            'email': 'junny@test.com'
+        }
+        response = client.put('/accounts/test/profile/', data_email_change)
+
+        self.assertEqual('junny@test.com', response.data.get('user').get('email'))
+
+        data_username_change = {
+            'username': 'Lee Hyeok-Jun'
+        }
+        client.put('/accounts/test/profile/', data_username_change)
+        response = client.get('/accounts/test/profile/')
+
+        self.assertEqual('Lee Hyeok-Jun', response.data.get('username'))
+
+        data_multiple_change = {
+            'email': 'junny@test.com',
+            'username': 'Lee Hyeok-Jun'
+        }
+        client.put('/accounts/test/profile/', data_multiple_change)
+        response = client.get('/accounts/test/profile/')
+
+        self.assertEqual('junny@test.com', response.data.get('email'))
+        self.assertEqual('Lee Hyeok-Jun', response.data.get('username'))
+
+        data_userid_change_same = {
+            'user_id': 'test2'
+        }
+        response = client.put('/accounts/test/profile/', data_userid_change_same)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+
+        data_password_change = {
+            'password': 'jhlee0210'
+        }
+        client.put('/accounts/test/profile/', data_password_change)
+        user = User.objects.get(user_id='test')
+
+        self.assertEqual(True, user.check_password('jhlee0210'))
+
+    def test_check_user_and_token_over_exp_limit_day(self):
+        user = User.objects.get(user_id='test')
+        uidb64 = urlsafe_base64_encode(force_bytes(user.user_pk))
+        token = default_token_generator.make_token(user=user)
+
+        response = self.client.get(f'/accounts/checkuser/redirect/{uidb64}/{token}')
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        class DefTokenGen(PasswordResetTokenGenerator):
+
+            def _today(self):
+                return date.today() + timedelta(days=10)
+
+        token_generator = DefTokenGen()
+
+        self.assertFalse(token_generator.check_token(user, token))

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -3,13 +3,13 @@ from datetime import date
 
 from django.utils.http import base36_to_int
 from rest_framework.test import APITestCase, APIClient
+
 from .authentication import *
 from .serializers import jwt_encode_handler
 from .views import *
 from django.core import mail
 from django.contrib.auth.tokens import default_token_generator
 
-from allauth.utils import get_user_model
 from .models import *
 from django.test import TestCase
 
@@ -302,6 +302,15 @@ class ViewTest(APITestCase):
         self.assertEqual(1, user.user_pk)
         self.assertEqual(True, check_token)
 
+    def test_check_current_domain(self):
+        from django.test.client import RequestFactory
+        rf = RequestFactory()
+        rf.ALLOWED_HOSTS = ['127.0.0.1']
+        rf.defaults['SERVER_NAME'] = '127.0.0.1'
+        get_request = rf.get('/hello/')
+
+        self.assertEqual('http://127.0.0.1', get_request._current_scheme_host)
+
     def test_send_verification_email(self):
         user = User.objects.get(user_id='test')
         request = {
@@ -361,3 +370,9 @@ class ViewTest(APITestCase):
         self.assertEqual("bnbong@naver.com", user_info['email'])
         self.assertEqual("준혁", user_info['first_name'])
         self.assertEqual("이", user_info['last_name'])
+
+    def test_make_reverse_url_with_format_string(self):
+        redirect_uri = reverse('accounts:google_login_redirect')
+        uri = f'http://localhost:9080{redirect_uri}'
+
+        self.assertEqual('http://localhost:9080/accounts/sociallogin/google/redirect/', uri)

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -351,11 +351,11 @@ class ViewTest(APITestCase):
         self.assertEqual(True, (default_token_generator._num_days(over_day) - ts) > settings.PASSWORD_RESET_TIMEOUT_DAYS)
 
     def test_social_login_access_token_slice(self):
-        user_info = {"id":"2765926233674432",
+        user_info = {"id":"my_id_here",
                      "first_name":"\uc900\ud601",
                      "last_name":"\uc774",
                      "picture":{"data":{"height":50,"is_silhouette":False,
-                                        "url":"https:\/\/platform-lookaside.fbsbx.com\/platform\/profilepic\/?asid=2765926233674432&height=50&width=50&ext=1614094176&hash=AeSg2JqKp0oaWcsKKW8",
+                                        "url":"profile_url_here",
                                         "width":50}},
                      "email":"bnbong\u0040naver.com"}
         self.assertEqual("bnbong@naver.com", user_info['email'])

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -5,6 +5,7 @@ from . import views, socialloginview
 app_name = 'accounts'
 
 urlpatterns = [
+
     path('login/', views.UserLogin.as_view()),
     path('register/', views.UserRegister.as_view()),
 
@@ -20,8 +21,20 @@ urlpatterns = [
     path('<user_id>/following/', views.UserFollowing.as_view(), name='user_following'),
     path('register/activate/<str:uidb64>/<str:token>', views.UserActivate.as_view(), name='activate_user'),
 
+]
+
+social_login_urls = [
+
+    # Facebook
     path('sociallogin/facebook/', socialloginview.fblogin, name='facebook_login'),
     path('sociallogin/facebook/redirect/', socialloginview.fblogin_redirect, name='facebook_login_redirect'),
+
+    # Google
+    path('sociallogin/google/', socialloginview.gglogin, name='google_login'),
+    path('sociallogin/google/redirect/', socialloginview.gglogin_redirect, name='google_login_redirect'),
+
 ]
+
+urlpatterns += social_login_urls
 
 

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -5,7 +5,7 @@ from . import views
 app_name = 'accounts'
 
 urlpatterns = [
-    path('rest-auth/google/', views.GoogleLogin.as_view(), name='google_login'),
+    path('rest-auth/google/', views.FacebookLogin.as_view(), name='facebook_login'),
 
     path('login/', views.UserLogin.as_view()),
     path('register/', views.UserRegister.as_view()),

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -19,6 +19,8 @@ urlpatterns = [
     path('<user_id>/unfollow/', views.UnFollowUser.as_view(), name='unfollow_user'),
     path('<user_id>/followers/', views.UserFollowers.as_view(), name='user_followers'),
     path('<user_id>/following/', views.UserFollowing.as_view(), name='user_following'),
+    path('<user_id>/checkuser/', views.CheckUser.as_view(), name='user_check'),
+    path('checkuser/redirect/<str:uidb64>/<str:token>', views.VerifyUser.as_view(), name='user_check_redirect'),
     path('register/activate/<str:uidb64>/<str:token>', views.UserActivate.as_view(), name='activate_user'),
 
 ]

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,12 +1,10 @@
 from django.urls import path
 
-from . import views
+from . import views, socialloginview
 
 app_name = 'accounts'
 
 urlpatterns = [
-    path('rest-auth/google/', views.FacebookLogin.as_view(), name='facebook_login'),
-
     path('login/', views.UserLogin.as_view()),
     path('register/', views.UserRegister.as_view()),
 
@@ -21,4 +19,9 @@ urlpatterns = [
     path('<user_id>/followers/', views.UserFollowers.as_view(), name='user_followers'),
     path('<user_id>/following/', views.UserFollowing.as_view(), name='user_following'),
     path('register/activate/<str:uidb64>/<str:token>', views.UserActivate.as_view(), name='activate_user'),
+
+    path('sociallogin/facebook/', socialloginview.fblogin, name='facebook_login'),
+    path('sociallogin/facebook/redirect/', socialloginview.fblogin_redirect, name='facebook_login_redirect'),
 ]
+
+

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -36,5 +36,3 @@ social_login_urls = [
 ]
 
 urlpatterns += social_login_urls
-
-

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -448,6 +448,8 @@ class CheckUser(APIView):
         send_verification_email(request, user=user, email=email,
                                 link='http://127.0.0.1:9080/accounts/checkuser/redirect')
 
+        return Response(data={"detail": _("Verification Email Sent.")}, status=status.HTTP_200_OK)
+
 
 class VerifyUser(APIView):
     """

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,4 +1,3 @@
-from allauth.socialaccount.providers.facebook.views import FacebookOAuth2Adapter
 from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site
@@ -6,9 +5,7 @@ from django.core.mail import EmailMessage
 from django.db import IntegrityError
 from django.utils.encoding import force_text, force_bytes
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
-from rest_auth.registration.views import SocialLoginView
 from django.utils.translation import ugettext_lazy as _
-from allauth.socialaccount.providers.oauth2.client import OAuth2Client
 
 from rest_framework import permissions
 from rest_framework.views import APIView
@@ -20,11 +17,6 @@ from .serializers import UserSerializerWithToken, UserProfileSerializer, CustomR
     CustomVerifyJSONWebTokenSerializer, custom_jwt_payload_handler, CustomRefreshJSONWebTokenSerializer
 
 User = get_user_model()
-
-
-class FacebookLogin(SocialLoginView):
-    adapter_class = FacebookOAuth2Adapter
-    client_class = OAuth2Client
 
 
 class UserProfile(APIView):
@@ -275,6 +267,10 @@ class UserLogin(APIView):
             password = request.data.get('password')
 
             user = User.objects.get(email=email)
+            if user.is_social is True:
+                return Response(data={"detail": _("This account is social account. "
+                                                  "Please proceed login with 'Continue with Social Account'")}
+                                , status=status.HTTP_403_FORBIDDEN)
             if not user.check_password(password):
                 return Response(status=status.HTTP_401_UNAUTHORIZED)
             if user and user.is_active is False:

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     'django.contrib.sites',
 
     'allauth',
+    'allauth.account',
     'allauth.socialaccount',
     'allauth.socialaccount.providers.facebook',
     'drf_yasg',
@@ -104,7 +105,7 @@ ELASTICSEARCH_DSL = {
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'recordmusic',
         'USER': 'django',
         'PASSWORD': 'django',

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -50,10 +50,6 @@ INSTALLED_APPS = [
 
     'django.contrib.sites',
 
-    'allauth',
-    'allauth.account',
-    'allauth.socialaccount',
-    'allauth.socialaccount.providers.facebook',
     'drf_yasg',
     'django_elasticsearch_dsl',
 
@@ -166,6 +162,9 @@ REST_FRAMEWORK = {
 }
 
 AUTH_USER_MODEL = 'accounts.User'
+
+FACEBOOK_APP_ID = '186620366569321'
+FACEBOOK_APP_SECRET = '9998a8b88c0c6020e0f4aaa1dd69a4fd'
 
 # EMAIL_BACKEND so allauth can proceed to send confirmation emails
 # ONLY for development/testing use console

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -163,8 +163,15 @@ REST_FRAMEWORK = {
 
 AUTH_USER_MODEL = 'accounts.User'
 
+# Third party app's client info which provides OAuth 2.0
+
+# Owner : Jun-Hyeok Lee(bnbong@naver.com), app name : recordmusic, status : developing
 FACEBOOK_APP_ID = '186620366569321'
 FACEBOOK_APP_SECRET = '9998a8b88c0c6020e0f4aaa1dd69a4fd'
+
+# Owner : Jun-Hyeok Lee(bbbong9@gmail.com), app name : recordmusic, status : test
+GOOGLE_APP_ID = '778918865045-m98cbij91l05ri5gjfu61oe00sbhljnr.apps.googleusercontent.com'
+GOOGLE_APP_SECRET = 'OpVvRH_IBvlZ6c2lfnXnJGyy'
 
 # EMAIL_BACKEND so allauth can proceed to send confirmation emails
 # ONLY for development/testing use console
@@ -176,7 +183,8 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
-PASSWORD_RESET_TIMEOUT_DAYS = 1  # give valid email confirmation deadline 1 day.
+# give valid email confirmation deadline for 1 day.
+PASSWORD_RESET_TIMEOUT_DAYS = 1
 
 REST_AUTH_SERIALIZERS = {
     'USER_DETAILS_SERIALIZER': 'accounts.serializers.UserSerializerWithToken',

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -13,6 +13,10 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 import os
 import datetime
 
+from dotenv import load_dotenv
+
+load_dotenv(verbose=True)
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -20,7 +24,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '94^7rj)i^oi@jqmptp!jjng0(sv((02omz)fzdm)pt7wwa2=sa'
+SECRET_KEY = os.getenv('secret_key')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -166,12 +170,12 @@ AUTH_USER_MODEL = 'accounts.User'
 # Third party app's client info which provides OAuth 2.0
 
 # Owner : Jun-Hyeok Lee(bnbong@naver.com), app name : recordmusic, status : developing
-FACEBOOK_APP_ID = '186620366569321'
-FACEBOOK_APP_SECRET = '9998a8b88c0c6020e0f4aaa1dd69a4fd'
+FACEBOOK_APP_ID = os.getenv('facebook_app_id')
+FACEBOOK_APP_SECRET = os.getenv('facebook_app_secret')
 
 # Owner : Jun-Hyeok Lee(bbbong9@gmail.com), app name : recordmusic, status : test
-GOOGLE_APP_ID = '778918865045-m98cbij91l05ri5gjfu61oe00sbhljnr.apps.googleusercontent.com'
-GOOGLE_APP_SECRET = 'OpVvRH_IBvlZ6c2lfnXnJGyy'
+GOOGLE_APP_ID = os.getenv('google_app_id')
+GOOGLE_APP_SECRET = os.getenv('google_app_secret')
 
 # EMAIL_BACKEND so allauth can proceed to send confirmation emails
 # ONLY for development/testing use console

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -181,8 +181,8 @@ GOOGLE_APP_SECRET = os.getenv('google_app_secret')
 # ONLY for development/testing use console
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = "smtp.gmail.com"
-EMAIL_HOST_USER = 'email here'
-EMAIL_HOST_PASSWORD = 'password here'
+EMAIL_HOST_USER = os.getenv('email_host_user')
+EMAIL_HOST_PASSWORD = os.getenv('email_host_password')
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -44,7 +44,6 @@ INSTALLED_APPS = [
 
     # Third Party Apps
     'rest_framework',
-    'rest_framework.authtoken',
 
     'rest_auth',
     'rest_auth.registration',
@@ -52,7 +51,6 @@ INSTALLED_APPS = [
     'django.contrib.sites',
 
     'allauth',
-    'allauth.account',
     'allauth.socialaccount',
     'allauth.socialaccount.providers.facebook',
     'drf_yasg',

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,6 +34,7 @@ PyJWT==1.7.1
 pyparsing==2.4.7
 pyrsistent==0.17.3
 python-dateutil==2.8.1
+python-dotenv==0.15.0
 python3-openid==3.2.0
 pytz==2020.4
 PyYAML==5.3.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,6 @@ coreschema==0.0.4
 cryptography==3.2.1
 defusedxml==0.7.0rc1
 Django==3.0.5
-django-allauth==0.43.0
 django-braces==1.14.0
 django-elasticsearch-dsl==7.1.4
 django-oauth-toolkit==1.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ PyJWT==1.7.1
 pyparsing==2.4.7
 pyrsistent==0.17.3
 python-dateutil==2.8.1
+python-dotenv==0.15.0
 python3-openid==3.2.0
 pytz==2020.4
 PyYAML==5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ coreschema==0.0.4
 cryptography==3.2.1
 defusedxml==0.7.0rc1
 Django==3.0.5
-django-allauth==0.43.0
 django-braces==1.14.0
 django-elasticsearch-dsl==7.1.4
 django-oauth-toolkit==1.3.3


### PR DESCRIPTION
## Description (요약)
google, facebook 소셜 로그인 기능 구현, User 모델에서 Follow 모델 분리, 더 이상 사용하지 않는 allauth 라이브러리 삭제, python-dotenv로 프로젝트 secret key 및 third party app client id & secret 키 분리, 유저 프로필 수정 기능 추가

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)
localhost web environment (port 9080)

## Major Changes (주요 변경사항)
 - Follow 모델 분리 -> 효율성을 위해 User 모델에서 follow 관련 필드를 모델로 분리.
 - Google & Facebook 소셜 로그인 기능 구현 -> client 로그인 화면에 구현될 소셜 계정으로 로그인 버튼만 클릭하면 해당 연결된 소셜 앱의 계정으로 새로운 계정을 만들 수 있고 로그인 할 수 있다.
 - User 필드에 is_social (Boolean, default=False)추가 -> 유저의 소셜 계정 정보를 바탕으로 만들어진 계정은 is_social 값이 True로 저장되며, 이는 일반 유저와 소셜 계정 유저의 로그인을 철저하게 분리하기 위해 만들어진 필드이다. is_social이 True로 저장된 유저는 유저가 email과 password를 직접 작성하는 일반 로그인 기능을 사용할 수 없으며, 클라이언트 화면에 나와있는 소셜 계정으로 로그인 버튼을 클릭하여 로그인 해야한다.
 - 추가 : Third party application이 제공해준 유저 정보를 바탕으로 유저 계정을 생성할 때, 해당 계정의 password는 서버에서 자동으로 무작위 password를 지정하여 저장한다. 유저의 닉네임(user_id)는 이메일의 @ 앞부분의 string으로 저장된다.
 - allauth 라이브러리 삭제 -> 초기에 allauth가 제공하는 소셜 계정 로그인 및 계정 관리, 소셜 앱 관리 기능을 사용하여 백엔드를 구현하려 했으나 allauth를 사용하지 않고 해당 기능들을 모두 구현했기 때문.
 - python-dotenv로 secret key 관리 -> project secret key, Facebook & Google client id & secret key, email_host_user & email_host_password 가 저장되며, .gitignore에 .env 파일 추가됨, 팀 slack에 .env파일이 공유될 예정(email_host_user와 email_host_password는 개별 testing을 진행할 시 직접 추가).

## Screenshots (optional)
![facebook_response](https://user-images.githubusercontent.com/55042923/105705472-9d3ee080-5f53-11eb-8b83-cc154bab78f4.png)
Facebook 소셜 계정을 통해 유저를 생성한 후 response. 생성된 소셜 계정으로 로그인 할 때도 같은 url({domain}/accounts/sociallogin/{socialappname}/)으로 접근하면 된다.
![facebook_login_result](https://user-images.githubusercontent.com/55042923/105704959-e2aede00-5f52-11eb-8b1b-3189b7d27efd.png)
Facebook 소셜 계정 정보로 유저가 생성된 모습.
![google_login_process](https://user-images.githubusercontent.com/55042923/105705619-d11a0600-5f53-11eb-999e-5f798d4680a7.png)
Google 소셜 로그인 과정
![google_response](https://user-images.githubusercontent.com/55042923/105705533-b5aefb00-5f53-11eb-82bc-eb858dcf58d5.png)
Google 소셜 계정을 통해 유저를 생성한 후 response.
![google_login_result](https://user-images.githubusercontent.com/55042923/105705045-fbb78f00-5f52-11eb-8bf6-af337d51071f.png)
Google 소셜 계정 정보로 유저가 생성된 모습. 이때, 유저의 정보 중 유저가 공개를 허락하지 않은 정보는(이메일 제외, 이메일은 필수로 입력받게 구현했다) 빈칸으로 처리하고 저장(사진을 예로 들면 유저 본인의 성명이 비공개일 경우 username필드를 빈칸으로 설정한 후 저장).

## Etc (비고)
다음 구현 계획 : user 삭제(회원 탈퇴 기능), imagefield testing 및 user profile image 업로드 및 변경 (using static folder, 실제 deploy시 AWS의 S3를 사용할 예정)

**API docs 변경 사항**
1. 유저 회원가입 (기존에 문서에 존재하던 기능)
> POST /accounts/register
- request
이전과 동일

- response
``` json
    {
        "detail": string
    }

// After verifying account process..
// In UserActivate view
    {
       "isSuccess": Boolean
    }
```

2. 유저 본인 확인 (새로 추가된 기능)
> POST /accounts/<user_id>/checkuser
 - request
``` json
// only need user_id from url
    {

    }
```
 - response
``` json
    {
        "detail": string
    }

// After verifying account process..
// In VerifyUser view
    {
       "isSuccess": Boolean
    }
```