### PR TITLE
[RM-44] 스포티파이 음악 및 가수 검색 기능 구현, 스포티파이 계정 연동 기능 구현(세부기능 미완성)

### DIFF
--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -672,6 +672,18 @@ class SubUserAccountViewTest(TestCase):
         self.assertEqual(True, passed_time >= 1)
         self.assertEqual(int, type(passed_time))
 
+    def test_b64encode_client(self):
+        import base64
+
+        app_id = settings.SPOTIFY_APP_ID
+        app_secret = settings.SPOTIFY_APP_SECRET
+        string = f'{app_id}:{app_secret}'
+        byte_string = string.encode('ascii')
+        b64encoded = base64.b64encode(byte_string)
+
+        # b64encoded string must be enclude with decoded string. ex) b64encoded.decode()
+        self.assertEqual(type(b64encoded), type(byte_string))
+
 
 class UserAccountFailTest(TestCase):
     """

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -38,6 +38,10 @@ social_login_urls = [
     path('sociallogin/google/', socialloginview.gglogin, name='google_login'),
     path('sociallogin/google/redirect/', socialloginview.gglogin_redirect, name='google_login_redirect'),
 
+    # Spotify
+    path('sociallogin/spotify/', socialloginview.splogin, name='spotify_login'),
+    path('sociallogin/spotify/redirect/', socialloginview.splogin_redirect, name='spotify_login_redirect'),
+
 ]
 
 urlpatterns += social_login_urls

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -32,10 +32,11 @@ DEBUG = True
 ALLOWED_HOSTS = [
     'localhost',
     '127.0.0.1',
-    'web'
+    'web',
+    'digging.cloud',
+    'digging.world',
     # '.ap-northeast-2.compute.amazonaws.com',
     # '.gift-music.com'
-
 ]
 
 # Application definition
@@ -190,6 +191,10 @@ FACEBOOK_APP_SECRET = os.getenv('facebook_app_secret')
 # Owner : Jun-Hyeok Lee(bbbong9@gmail.com), app name : recordmusic, status : test
 GOOGLE_APP_ID = os.getenv('google_app_id')
 GOOGLE_APP_SECRET = os.getenv('google_app_secret')
+
+# Owner : Jun-Hyeok Lee(bbbong9@gmail.com), app name : record music
+SPOTIFY_APP_ID = os.getenv('spotify_app_id')
+SPOTIFY_APP_SECRET = os.getenv('spotify_app_secret')
 
 # EMAIL_BACKEND so allauth can proceed to send confirmation emails
 # ONLY for development/testing use console

--- a/backend/music/tests.py
+++ b/backend/music/tests.py
@@ -10,6 +10,8 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models import ImageField
 from django.test import TestCase
 from rest_framework.test import APIClient
+
+from backend import settings
 from .models import *
 
 
@@ -62,3 +64,29 @@ class ModelTest(TestCase):
         self.assertEqual('TestMusicName', music.name)
         self.assertEqual('1', music.yt_song_id)
         self.assertEqual('...', music.cover_image)
+
+    def test_spotify_search(self):
+        import base64
+        import requests
+
+        app_id = settings.SPOTIFY_APP_ID
+        app_secret = settings.SPOTIFY_APP_SECRET
+
+        client_info = f'{app_id}:{app_secret}'
+        encoded_string = client_info.encode('ascii')
+        b64encoded = base64.b64encode(encoded_string)
+
+        header = f'Basic {b64encoded.decode()}'
+
+        uri = requests.post('https://accounts.spotify.com/api/token', headers={'Authorization': header},
+                            data={'grant_type': 'client_credentials'})
+
+        access_token = uri.json()['access_token']
+        header = f'Bearer {access_token}'
+
+        uri = requests.get('https://api.spotify.com/v1/search', headers={'Authorization': header}, params={
+            'q': 'yummy',
+            'type': 'track',
+        })
+
+        self.assertIsNotNone(uri.content)

--- a/backend/music/urls.py
+++ b/backend/music/urls.py
@@ -8,4 +8,5 @@ app_name = 'music'
 
 urlpatterns = [
     path('', views.MusicView.as_view()),
+    path('search/', views.SpotifyMusicSearch.as_view()),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/music/views.py
+++ b/backend/music/views.py
@@ -1,7 +1,14 @@
+import requests
+from django.shortcuts import redirect
+from django.urls import reverse
 from rest_framework import status, permissions
+from rest_framework.decorators import api_view, permission_classes, renderer_classes
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from accounts import authentication
+from backend import settings
 from .serializers import *
 
 
@@ -53,3 +60,37 @@ class MusicView(APIView):
 
         music.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class SpotifyMusicSearch(APIView):
+
+    permission_classes = (permissions.AllowAny,)
+
+    def get(self, request):
+        import base64
+        import requests
+
+        app_id = settings.SPOTIFY_APP_ID
+        app_secret = settings.SPOTIFY_APP_SECRET
+
+        client_info = f'{app_id}:{app_secret}'
+        encoded_string = client_info.encode('ascii')
+        b64encoded = base64.b64encode(encoded_string)
+
+        header = f'Basic {b64encoded.decode()}'
+
+        uri = requests.post('https://accounts.spotify.com/api/token', headers={'Authorization': header},
+                            data={'grant_type': 'client_credentials'})
+
+        access_token = uri.json()['access_token']
+        header = f'Bearer {access_token}'
+
+        q = request.data.get('q')
+        type = request.data.get('type')
+
+        params = {'q': q, 'type': type}
+
+        uri = requests.get('https://api.spotify.com/v1/search', headers={'Authorization': header}, params=params)
+
+        return Response(uri.json())
+


### PR DESCRIPTION
## Description (요약)
Spotify api를 활용하여 음악 및 가수, 앨범 등을 검색할 수 있는 기능 구현, Spotify 계정을 연동하는 기능 구현(스포티파이 계정의 access token 만 불러오는 기능만 구현, 개인 플레이 리스트 연동 기능 등 세부 기능 미구현)

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)
localhost with Postman

## Major Changes (주요 변경사항)
 - Spotify API를 활용하여 음악, 가수, 앨범, 트랙 등을 검색할 수 있는 기능 구현
 - Spotify 계정의 접근 권한을 얻는 과정을 통해 access token을 불러오는 기능 구현
 - .env 파일에 spotify 에 등록해 놓은 앱 클라이언트 id 및 secret 공유 예정(Slack)

## Screenshots (optional)
![music_search](https://user-images.githubusercontent.com/55042923/112125105-6bba5c80-8c06-11eb-83ff-1bdcdc45ee8e.png)


## Etc (비고)
그동안 Google, Facebook, Spotify 모두 redirect uri를 localhost 도메인으로 설정하고 개발을 했는데, 추후 구매했던 정식 도메인으로 모두 변경하도록 하겠습니다. 앞으로 몇 달 동안 개인적인 사정 때문에 연락이 힘들어질 수 있으니 이후 백엔드 개발을 맡으실 개발자분은 이번 PR과 관련된 문의 사항을 제 이메일(bbbong9@gmail.com) 이나 개인 연락처로 남겨주세요.
